### PR TITLE
Fixed related_name conflict in Recommendation model

### DIFF
--- a/bangazonapi/models/recommendation.py
+++ b/bangazonapi/models/recommendation.py
@@ -5,6 +5,8 @@ from .product import Product
 
 class Recommendation(models.Model):
 
-    customer = models.ForeignKey(Customer, related_name='recommendations', on_delete=models.DO_NOTHING,)
+    customer = models.ForeignKey(
+        Customer, related_name='recommendations_receiver', on_delete=models.DO_NOTHING,)
     product = models.ForeignKey(Product, on_delete=models.DO_NOTHING,)
-    recommender = models.ForeignKey(Customer, related_name='recommendations', on_delete=models.DO_NOTHING,)
+    recommender = models.ForeignKey(
+        Customer, related_name='recommendations_giver', on_delete=models.DO_NOTHING,)


### PR DESCRIPTION
When attempting to `makemigrations`, received the following error:

```
bangazonapi.Recommendation.customer: (fields.E304) Reverse accessor for 'Recommendation.customer' clashes with reverse accessor for 'Recommendation.recommender'.
        HINT: Add or change a related_name argument to the definition for 'Recommendation.customer' or 'Recommendation.recommender'.
bangazonapi.Recommendation.customer: (fields.E305) Reverse query name for 'Recommendation.customer' clashes with reverse query name for 'Recommendation.recommender'.
        HINT: Add or change a related_name argument to the definition for 'Recommendation.customer' or 'Recommendation.recommender'.
bangazonapi.Recommendation.recommender: (fields.E304) Reverse accessor for 'Recommendation.recommender' clashes with reverse accessor for 'Recommendation.customer'.
        HINT: Add or change a related_name argument to the definition for 'Recommendation.recommender' or 'Recommendation.customer'.
bangazonapi.Recommendation.recommender: (fields.E305) Reverse query name for 'Recommendation.recommender' clashes with reverse query name for 'Recommendation.customer'.
        HINT: Add or change a related_name argument to the definition for 'Recommendation.recommender' or 'Recommendation.customer'.
```

## Changes

- Changed `customer` related_name to: `recommendations_receiver`
- Changed `recommender` related_name to: `recommendations_giver`


## Requests / Responses

**N/A**

## Testing

Description of how to test code...

- [ ] Run migrations


## Related Issues

**N/A**