### PR TITLE
Nw/fixes/11 div by zero

### DIFF
--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -63,7 +63,7 @@ class Product(SafeDeleteModel):
             total_rating += rating.rating
 
         # If there are no ratings, then we set the average to 0
-        # otherwise (ratings > 0), we calculate the average
+        # otherwise we calculate the average
         try:
             avg = total_rating / len(ratings)
         except ZeroDivisionError:

--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -62,7 +62,13 @@ class Product(SafeDeleteModel):
         for rating in ratings:
             total_rating += rating.rating
 
-        avg = total_rating / len(ratings)
+        # If there are no ratings, then we set the average to 0
+        # otherwise (ratings > 0), we calculate the average
+        try:
+            avg = total_rating / len(ratings)
+        except ZeroDivisionError:
+            avg = total_rating
+
         return avg
 
     class Meta:


### PR DESCRIPTION
When there were 0 ratings, `average_rating` was attempting to divide by 0 causing a ZeroDivisionError.

## Changes

- Added try/except block around the average calculation, which catches the `ZeroDivisionError`.  When caught, it sets the average rating to 0 since there haven't been any reviews yet.

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**N/A**

## Testing

Description of how to test code...

- [ ] Seed/Migrate database (run `seed_data.sh`)
- [ ] Submit GET request to `/profile/cart` endpoint
- [ ] Verify you receive cart data back and NOT a `ZeroDivisionError`


## Related Issues

- Fixes #11