### PR TITLE
Data references for expiration and creation dates were swapped. Fixed that, tests pass.

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -34,8 +34,8 @@ class Payments(ViewSet):
         new_payment = Payment()
         new_payment.merchant_name = request.data["merchant_name"]
         new_payment.account_number = request.data["account_number"]
-        new_payment.expiration_date = request.data["create_date"]
-        new_payment.create_date = request.data["expiration_date"]
+        new_payment.expiration_date = request.data["expiration_date"]
+        new_payment.create_date = request.data["create_date"]
         customer = Customer.objects.get(user=request.auth.user)
         new_payment.customer = customer
         new_payment.save()


### PR DESCRIPTION
When creating a payment type via POST to `/paymenttypes`, the `create_date` and `expiration_dates` were swapped in the response as compared to the submitted body in the request.  This resulted in the creation date being set as the expiration and the expiration set as the creation date.

## Changes

- Referenced respective `expiration_date` and `create_date` request data for the respective fields.


## Requests / Responses

**Request**

POST `/paymenttypes` Creates a new payment type

```json
{
    "merchant_name": "Amex",
    "account_number": "000000000000",
    "expiration_date": "2023-12-12",
    "create_date": "2020-12-12"
}
```

**Response**

HTTP/1.1 201 OK

```json
{
    "id": 5,
    "url": "http://localhost:8000/paymenttypes/5",
    "merchant_name": "Amex",
    "account_number": "000000000000",
    "expiration_date": "2023-12-12",
    "create_date": "2020-12-12"
}
```

## Testing

- [ ] Run seed/migrate script
- [ ] Run test suite -> `python manage.py test tests.PaymentTests`


## Related Issues

- Fixes #7