### PR TITLE
Nw/enhancement/15 add payment type to order

### DIFF
--- a/bangazonapi/views/order.py
+++ b/bangazonapi/views/order.py
@@ -24,6 +24,7 @@ class OrderLineItemSerializer(serializers.HyperlinkedModelSerializer):
         fields = ('id', 'product')
         depth = 1
 
+
 class OrderSerializer(serializers.HyperlinkedModelSerializer):
     """JSON serializer for customer orders"""
 
@@ -35,7 +36,8 @@ class OrderSerializer(serializers.HyperlinkedModelSerializer):
             view_name='order',
             lookup_field='id'
         )
-        fields = ('id', 'url', 'created_date', 'payment_type', 'customer', 'lineitems')
+        fields = ('id', 'url', 'created_date',
+                  'payment_type', 'customer', 'lineitems')
 
 
 class Orders(ViewSet):
@@ -84,7 +86,7 @@ class Orders(ViewSet):
 
     def update(self, request, pk=None):
         """
-        @api {PUT} /order/:id PUT new payment for order
+        @api {PUT} /orders/:id PUT new payment for order
         @apiName AddPayment
         @apiGroup Orders
 
@@ -104,7 +106,8 @@ class Orders(ViewSet):
         """
         customer = Customer.objects.get(user=request.auth.user)
         order = Order.objects.get(pk=pk, customer=customer)
-        order.payment_type = request.data["payment_type"]
+        order.payment_type = Payment.objects.get(
+            pk=request.data["payment_type"])
         order.save()
 
         return Response({}, status=status.HTTP_204_NO_CONTENT)

--- a/tests/order.py
+++ b/tests/order.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 from rest_framework import status
 from rest_framework.test import APITestCase
@@ -24,11 +25,24 @@ class OrderTests(APITestCase):
 
         # Create a product
         url = "/products"
-        data = { "name": "Kite", "price": 14.99, "quantity": 60, "description": "It flies high", "category_id": 1, "location": "Pittsburgh" }
+        data = {"name": "Kite", "price": 14.99, "quantity": 60,
+                "description": "It flies high", "category_id": 1, "location": "Pittsburgh"}
         self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
         response = self.client.post(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
+        # Create a PaymentType
+        url = "/paymenttypes"
+        data = {
+            "merchant_name": "American Express",
+            "account_number": "111-1111-1111",
+            "expiration_date": "2024-12-31",
+            "create_date": datetime.date.today()
+        }
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.post(url, data, format='json')
+        json_response = json.loads(response.content)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     def test_add_product_to_order(self):
         """
@@ -36,7 +50,7 @@ class OrderTests(APITestCase):
         """
         # Add product to order
         url = "/cart"
-        data = { "product_id": 1 }
+        data = {"product_id": 1}
         self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
         response = self.client.post(url, data, format='json')
 
@@ -53,7 +67,6 @@ class OrderTests(APITestCase):
         self.assertEqual(json_response["size"], 1)
         self.assertEqual(len(json_response["lineitems"]), 1)
 
-
     def test_remove_product_from_order(self):
         """
         Ensure we can remove a product from an order.
@@ -63,7 +76,7 @@ class OrderTests(APITestCase):
 
         # Remove product from cart
         url = "/cart/1"
-        data = { "product_id": 1 }
+        data = {"product_id": 1}
         self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
         response = self.client.delete(url, data, format='json')
 
@@ -79,6 +92,29 @@ class OrderTests(APITestCase):
         self.assertEqual(json_response["size"], 0)
         self.assertEqual(len(json_response["lineitems"]), 0)
 
-    # TODO: Complete order by adding payment type
+    # Complete order by adding payment type
+    def test_add_payment_type_to_order(self):
+        """
+        Ensure we can add a payment type to an order.
+        """
+        self.test_add_product_to_order()
+
+        # Add payment_type to order
+        url = "/orders/1"
+        data = {"payment_type": 1}
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.put(url, data, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        # Get order and verify payment_type was added
+        url = "/orders/1"
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.get(url, None, format='json')
+        json_response = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(json_response["id"], 1)
+        self.assertEqual(json_response["payment_type"].split("/")[-1], "1")
 
     # TODO: New line item is not added to closed order


### PR DESCRIPTION
Fixes payment type reference in `views/order.py` and adds integration test to validate we can add a payment type to an order.

## Changes

- Assign a `Payment` instance to `payment_type` instead of strictly the `id`.
- Create a payment type in the setup for `tests/order.py` to later be used to add to an order.
- Create `test_add_payment_type_to_order` integration test to validate adding a payment_type value to an order.
- Fix a docstring error where the URL was referencing a `/order/:id` path instead of the correct `/orders/:id` path.

## Requests / Responses
**N/A**

## Testing

Description of how to test code...

- [ ] Run seed/migration script
- [ ] Run test suite -> `python manage.py test tests.OrderTests -v 1`


## Related Issues

- Fixes #15