### PR TITLE
Nw/fix enhancement/3 16 products added to closed orders tests

### DIFF
--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -211,8 +211,9 @@ class Profile(ViewSet):
             """
 
             try:
-                open_order = Order.objects.get(customer=current_user)
-                print(open_order)
+                open_order = Order.objects.get(
+                    customer=current_user, payment_type__isnull=True)
+
             except Order.DoesNotExist as ex:
                 open_order = Order()
                 open_order.created_date = datetime.datetime.now()

--- a/tests/order.py
+++ b/tests/order.py
@@ -118,3 +118,29 @@ class OrderTests(APITestCase):
         self.assertEqual(json_response["payment_type"].split("/")[-1], "1")
 
     # TODO: New line item is not added to closed order
+    def test_new_line_item_not_added_to_closed_order(self):
+        """
+        Ensure that we do not add a new line item to a closed order
+        """
+
+        # Close out the first order by adding a payment_type to that order
+        self.test_add_payment_type_to_order()
+
+        # Add product to a new order
+        url = "/cart"
+        data = {"product_id": 1}
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.post(url, data, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        # Get cart and verify product was added
+        url = "/cart"
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.get(url, None, format='json')
+        json_response = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(json_response["id"], 2)
+        self.assertEqual(json_response["size"], 1)
+        self.assertEqual(len(json_response["lineitems"]), 1)


### PR DESCRIPTION
Added additional filter in `get` query for open orders in `views/profile.py` to ignore any orders which already had a payment type assigned.  Also added a test to verify a new order is created after closing a previously-open order.

## Changes

- Added `payment_type__isnull` filter in the `get` query for open orders in the profile view.
- Add additional test to verify a new order is created after closing a previous one.

## Requests / Responses

**N/A**

## Testing

Description of how to test code...

- [ ] Run test suite -> `python manage.py test tests.OrderTests.test_new_line_item_not_added_to_closed_order -v 1`


## Related Issues

- Fixes #3
- Closes #16