### PR TITLE
Nw/fixes/6 delete item from cart

### DIFF
--- a/bangazonapi/views/lineitem.py
+++ b/bangazonapi/views/lineitem.py
@@ -37,20 +37,19 @@ class LineItems(ViewSet):
 
     def retrieve(self, request, pk=None):
         """
-        @api {GET} /lineitems/:id DELETE line item from cart
-        @apiName RemoveLineItem
+        @api {GET} /lineitems/:id GET line item from cart
+        @apiName GetLineItem
         @apiGroup ShoppingCart
 
         @apiHeader {String} Authorization Auth token
         @apiHeaderExample {String} Authorization
             Token 9ba45f09651c5b0c404f37a2d2572c026c146611
 
-        @apiParam {id} id Product Id to remove from cart
+        @apiParam {id} id LineItem (order_product) Id to get from cart
         @apiSuccessExample {json} Success
-            HTTP/1.1 204 No Content
+            HTTP/1.1 200 OK
         """
         try:
-            # line_item = OrderProduct.objects.get(pk=pk)
             customer = Customer.objects.get(user=request.auth.user)
             line_item = OrderProduct.objects.get(
                 pk=pk, order__customer=customer)
@@ -73,7 +72,7 @@ class LineItems(ViewSet):
         @apiHeaderExample {String} Authorization
             Token 9ba45f09651c5b0c404f37a2d2572c026c146611
 
-        @apiParam {id} id Product Id to remove from cart
+        @apiParam {id} id LineItem (order_product) Id to remove from cart
         @apiSuccessExample {json} Success
             HTTP/1.1 204 No Content
         """

--- a/bangazonapi/views/lineitem.py
+++ b/bangazonapi/views/lineitem.py
@@ -18,6 +18,7 @@ class LineItemSerializer(serializers.HyperlinkedModelSerializer):
         )
         fields = ('id', 'url', 'order', 'product')
 
+
 class LineItems(ViewSet):
     """Line items for Bangazon orders"""
 
@@ -36,7 +37,7 @@ class LineItems(ViewSet):
 
     def retrieve(self, request, pk=None):
         """
-        @api {GET} /cart/:id DELETE line item from cart
+        @api {GET} /lineitems/:id DELETE line item from cart
         @apiName RemoveLineItem
         @apiGroup ShoppingCart
 
@@ -62,7 +63,7 @@ class LineItems(ViewSet):
 
     def destroy(self, request, pk=None):
         """
-        @api {DELETE} /cart/:id DELETE line item from cart
+        @api {DELETE} /lineitems/:id DELETE line item from cart
         @apiName RemoveLineItem
         @apiGroup ShoppingCart
 

--- a/bangazonapi/views/lineitem.py
+++ b/bangazonapi/views/lineitem.py
@@ -52,9 +52,11 @@ class LineItems(ViewSet):
         try:
             # line_item = OrderProduct.objects.get(pk=pk)
             customer = Customer.objects.get(user=request.auth.user)
-            line_item = OrderProduct.objects.get(pk=pk, order__customer=customer)
+            line_item = OrderProduct.objects.get(
+                pk=pk, order__customer=customer)
 
-            serializer = LineItemSerializer(line_item, context={'request': request})
+            serializer = LineItemSerializer(
+                line_item, context={'request': request})
 
             return Response(serializer.data)
 
@@ -77,7 +79,10 @@ class LineItems(ViewSet):
         """
         try:
             customer = Customer.objects.get(user=request.auth.user)
-            order_product = OrderProduct.objects.get(pk=pk, order__customer=customer)
+            order_product = OrderProduct.objects.get(
+                pk=pk, order__customer=customer)
+
+            order_product.delete()
 
             return Response({}, status=status.HTTP_204_NO_CONTENT)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,3 +2,4 @@ from .product import ProductTests
 from .order import OrderTests
 from .payments import PaymentTests
 from .profile import ProfileTests
+from .lineitem import LineitemTests

--- a/tests/lineitem.py
+++ b/tests/lineitem.py
@@ -1,0 +1,58 @@
+import json
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+
+class LineitemTests(APITestCase):
+    def setUp(self) -> None:
+        """
+        Create an account, product, and order
+        """
+        # Create account
+        url = "/register"
+        data = {"username": "steve", "password": "Admin8*", "email": "steve@stevebrownlee.com",
+                "address": "100 Infinity Way", "phone_number": "555-1212", "first_name": "Steve", "last_name": "Brownlee"}
+        response = self.client.post(url, data, format='json')
+        json_response = json.loads(response.content)
+        self.token = json_response["token"]
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        # Create a product category
+        url = "/productcategories"
+        data = {"name": "Sporting Goods"}
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.post(url, data, format='json')
+
+        # Create product
+        url = "/products"
+        data = {"name": "Kite", "price": 14.99, "quantity": 60,
+                "description": "It flies high", "category_id": 1, "location": "Pittsburgh"}
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        # Add product to order
+        url = "/cart"
+        data = {"product_id": 1}
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.post(url, data, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_delete_lineitem_from_cart(self):
+        # Remove lineitem from cart
+        url = "/lineitems/1"
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.delete(url, None, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        # Get cart and verify product was removed
+        url = "/cart"
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.get(url, None, format='json')
+        json_response = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(json_response["size"], 0)
+        self.assertEqual(len(json_response["lineitems"]), 0)


### PR DESCRIPTION
PR resolves issue with deleting line items from a card via the `/lineitems/:id` endpoint.  Also adds an integration test to validate that functionality.

## Changes

- Added `delete()` call on the `order_product` object in `views/lineitem.py` to actually delete the record.
- Added a `LineitemTests` module which includes a new test to validate the line item deletion is successful.
- Updated **APIdoc** docstrings to properly reference the `lineitems` endpoint and provide correct data and response information.

## Requests / Responses

**N/A**

## Testing

Description of how to test code...

- [ ] Run test suite  -> `python manage.py test tests.LineitemTests.test_delete_lineitem_from_cart -v 1`

```
$ python manage.py test tests.LineitemTests.test_delete_lineitem_from_cart -v 1
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
.
----------------------------------------------------------------------
Ran 1 test in 0.088s

OK
Destroying test database for alias 'default'...
```


## Related Issues

- Fixes #6