### PR TITLE
Nw/fixes/8 all payment types returned

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -83,10 +83,6 @@ class Payments(ViewSet):
 
         # Forcing the "query param" to be set as the current authenticated user.
         #
-        # After speaking with Mitchell, this was decided on to enforce the
-        # 'only the payment types added by the authenticated user should
-        # be returned' requirement of issue #8.
-        #
         # If supporting the 'customer' query param is required to provide
         # results for a user other than the authenticated user at a later
         # time, that should be handled by re-enabling the original filter

--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -81,10 +81,26 @@ class Payments(ViewSet):
         """Handle GET requests to payment type resource"""
         payment_types = Payment.objects.all()
 
+        # Forcing the "query param" to be set as the current authenticated user.
+        #
+        # After speaking with Mitchell, this was decided on to enforce the
+        # 'only the payment types added by the authenticated user should
+        # be returned' requirement of issue #8.
+        #
+        # If supporting the 'customer' query param is required to provide
+        # results for a user other than the authenticated user at a later
+        # time, that should be handled by re-enabling the original filter
+        # call along with some sort of permissions check.
+
         customer_id = self.request.query_params.get('customer', None)
 
         if customer_id is not None:
-            payment_types = payment_types.filter(customer__id=customer_id)
+            # payment_types = payment_types.filter(customer__id=customer_id)
+            payment_types = payment_types.filter(
+                customer__user=request.auth.user)
+        else:
+            payment_types = payment_types.filter(
+                customer__user=request.auth.user)
 
         serializer = PaymentSerializer(
             payment_types, many=True, context={'request': request})

--- a/tests/payments.py
+++ b/tests/payments.py
@@ -73,7 +73,18 @@ class PaymentTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         # Verify we only get the payment types belonging to the primary user
+        # when querying the `/paymenttypes` endpoint
         url = "/paymenttypes"
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.get(url, None, format='json')
+        json_response = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(json_response), 2)
+
+        # Verify we only get the payment types belonging to the primary user
+        # when querying the `/paymenttypes?customer=n` endpoint and query param
+        url = "/paymenttypes?customer=2"
         self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
         response = self.client.get(url, None, format='json')
         json_response = json.loads(response.content)

--- a/tests/payments.py
+++ b/tests/payments.py
@@ -17,6 +17,14 @@ class PaymentTests(APITestCase):
         self.token = json_response["token"]
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
+        # Create secondary account
+        url = "/register"
+        data = {"username": "secondary", "password": "Admin8*", "email": "steve@stevebrownlee.com",
+                "address": "100 Infinity Way", "phone_number": "555-1212", "first_name": "Steve", "last_name": "Brownlee"}
+        response = self.client.post(url, data, format='json')
+        json_response = json.loads(response.content)
+        self.token_secondary = json_response["token"]
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     def test_create_payment_type(self):
         """
@@ -38,6 +46,39 @@ class PaymentTests(APITestCase):
         self.assertEqual(json_response["merchant_name"], "American Express")
         self.assertEqual(json_response["account_number"], "111-1111-1111")
         self.assertEqual(json_response["expiration_date"], "2024-12-31")
-        self.assertEqual(json_response["create_date"], str(datetime.date.today()))
+        self.assertEqual(
+            json_response["create_date"], str(datetime.date.today()))
+
+    def test_get_payment_types(self):
+        """
+        Ensure we only get payment types for the current authenticated user
+        """
+        # Create payment types for primary user
+        self.test_create_payment_type()
+        self.test_create_payment_type()
+
+        # Create payment type for the secondary user
+        url = "/paymenttypes"
+        data = {
+            "merchant_name": "American Express",
+            "account_number": "111-1111-1111",
+            "expiration_date": "2024-12-31",
+            "create_date": datetime.date.today()
+        }
+        self.client.credentials(
+            HTTP_AUTHORIZATION='Token ' + self.token_secondary)
+        response = self.client.post(url, data, format='json')
+        json_response = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        # Verify we only get the payment types belonging to the primary user
+        url = "/paymenttypes"
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.get(url, None, format='json')
+        json_response = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(json_response), 2)
 
     # TODO: Delete payment type


### PR DESCRIPTION
Enforce payment types response to only send payment types for the current authenticated user (_regardless of what the `customer` query param is set as_).  Add integration test to verify only results for the current authenticated user are sent.

**NOTE:** If support for the `customer` query param is required, then it can be re-enabled and proper permissions checks should be utilized so every user does not have access to other user's payment details.

## Changes

- Applied authenticated user filter to all queries regardless of presence, or lack thereof, of a query param for the customer id.
- Added integration test to verify that both `/paymenttypes` and `/paymenttypes?customer=n` endpoints return only results for the current authenticated user.

## Requests / Responses

**N/A**

## Testing

Description of how to test code...

- [ ] Run test suite  -> `python manage.py test tests.PaymentTests.test_get_payment_types -v 1`

```
$ python manage.py test tests.PaymentTests.test_get_payment_types -v 1
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
.
----------------------------------------------------------------------
Ran 1 test in 0.138s

OK
Destroying test database for alias 'default'...
```


## Related Issues

- Fixes #8