### PR TITLE
Nw/enhancement/9 min price query param

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -252,6 +252,7 @@ class Products(ViewSet):
         order = self.request.query_params.get('order_by', None)
         direction = self.request.query_params.get('direction', None)
         number_sold = self.request.query_params.get('number_sold', None)
+        min_price = self.request.query_params.get('min_price', None)
 
         if order is not None:
             order_filter = order
@@ -275,6 +276,14 @@ class Products(ViewSet):
                 return False
 
             products = filter(sold_filter, products)
+
+        if min_price is not None:
+            def min_price_filter(product):
+                if product.price >= int(min_price):
+                    return True
+                return False
+
+            products = filter(min_price_filter, products)
 
         serializer = ProductSerializer(
             products, many=True, context={'request': request})

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -279,7 +279,7 @@ class Products(ViewSet):
 
         if min_price is not None:
             def min_price_filter(product):
-                if product.price >= int(min_price):
+                if product.price >= float(min_price):
                     return True
                 return False
 

--- a/tests/product.py
+++ b/tests/product.py
@@ -185,6 +185,16 @@ class ProductTests(APITestCase):
         self.assertEqual(len(json_response), 1)
         self.assertEqual(json_response[0]["id"], 1)
 
+        # Request products using decimal query param
+        url = "/products?min_price=14.99"
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.get(url, None, format='json')
+        json_response = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(json_response), 1)
+        self.assertEqual(json_response[0]["id"], 1)
+
     # TODO: Delete product
 
     # TODO: Product can be rated. Assert average rating exists.

--- a/tests/product.py
+++ b/tests/product.py
@@ -158,6 +158,33 @@ class ProductTests(APITestCase):
         self.assertEqual(len(json_response), 1)
         self.assertEqual(json_response[0]["id"], 1)
 
+    def test_products_min_price_query_param(self):
+        """
+        Ensure we can filter products based on a given minimum price
+        """
+
+        # Create a product
+        self.test_create_product()
+
+        # Request products >= 15 dollars (should return no results)
+        url = "/products?min_price=15"
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.get(url, None, format='json')
+        json_response = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(json_response), 0)
+
+        # Request products >= 14 dollars (should return 1 result)
+        url = "/products?min_price=14"
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.get(url, None, format='json')
+        json_response = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(json_response), 1)
+        self.assertEqual(json_response[0]["id"], 1)
+
     # TODO: Delete product
 
     # TODO: Product can be rated. Assert average rating exists.


### PR DESCRIPTION
Creates a `min_price` query param and filters products based on that value.  Adds an integration test to validate that query param functionality.

## Changes

- Add `min_price` query param support in the `list` function for `views/product.py`
- Add an integration test to `tests/product.py` to validate that functionality.

## Requests / Responses

**Request**

GET `/products?min_price=1989` -> Returns products with a price >= the given value

**Response**

HTTP/1.1 200 OK

```json
[
    {
        "id": 60,
        "name": "Elantra",
        "price": 1989.84,
        "number_sold": 0,
        "description": "1994 Hyundai",
        "quantity": 1,
        "created_date": "2019-01-19",
        "location": "Sosnovoborsk",
        "image_path": null,
        "average_rating": 0
    }
]
```

## Testing

Description of how to test code...

- [ ] Run test suite  -> `python manage.py test tests.ProductTests.test_products_min_price_query_param -v 1`

```
$ python manage.py test tests.ProductTests.test_products_min_price_query_param -v 1
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
.
----------------------------------------------------------------------
Ran 1 test in 0.083s

OK
Destroying test database for alias 'default'...
```


## Related Issues

- Fixes #9