### PR TITLE
Nw/fixes/10 maximum product price

### DIFF
--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -15,7 +15,7 @@ class Product(SafeDeleteModel):
     customer = models.ForeignKey(
         Customer, on_delete=models.DO_NOTHING, related_name='products')
     price = models.FloatField(
-        validators=[MinValueValidator(0.00), MaxValueValidator(10000.00)],)
+        validators=[MinValueValidator(0.00), MaxValueValidator(17500.00)],)
     description = models.CharField(max_length=255,)
     quantity = models.IntegerField(validators=[MinValueValidator(0)],)
     created_date = models.DateField(auto_now_add=True)

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -104,6 +104,7 @@ class Products(ViewSet):
 
             new_product.image_path = data
 
+        new_product.clean_fields()
         new_product.save()
 
         serializer = ProductSerializer(

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -106,7 +106,7 @@ class Products(ViewSet):
             new_product.image_path = data
 
         try:
-            new_product.clean_fields()
+            new_product.clean_fields(exclude="image_path")
         except ValidationError as ex:
             return Response({"message": ex.args[0]}, status=status.HTTP_400_BAD_REQUEST)
 
@@ -194,7 +194,7 @@ class Products(ViewSet):
         product.category = product_category
 
         try:
-            product.clean_fields()
+            product.clean_fields(exclude="image_path")
         except ValidationError as ex:
             return Response({"message": ex.args[0]}, status=status.HTTP_400_BAD_REQUEST)
 

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -108,7 +108,7 @@ class Products(ViewSet):
         try:
             new_product.clean_fields()
         except ValidationError as ex:
-            return Response({"message": ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response({"message": ex.args[0]}, status=status.HTTP_400_BAD_REQUEST)
 
         new_product.save()
 
@@ -192,6 +192,12 @@ class Products(ViewSet):
         product_category = ProductCategory.objects.get(
             pk=request.data["category_id"])
         product.category = product_category
+
+        try:
+            product.clean_fields()
+        except ValidationError as ex:
+            return Response({"message": ex.args[0]}, status=status.HTTP_400_BAD_REQUEST)
+
         product.save()
 
         return Response({}, status=status.HTTP_204_NO_CONTENT)

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -1,5 +1,6 @@
 """View module for handling requests about products"""
 import base64
+from django.core.exceptions import ValidationError
 from django.core.files.base import ContentFile
 from django.http import HttpResponseServerError
 from rest_framework.viewsets import ViewSet
@@ -104,7 +105,11 @@ class Products(ViewSet):
 
             new_product.image_path = data
 
-        new_product.clean_fields()
+        try:
+            new_product.clean_fields()
+        except ValidationError as ex:
+            return Response({"message": ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
         new_product.save()
 
         serializer = ProductSerializer(


### PR DESCRIPTION
Updates product view to enforce validators.  Updates maximum allowed price.  Adds test to verify validators are enforced properly.

## Changes

- Added a call to `clean_fields(exclude="image_path")` prior to the save calls in both the Product `create` and `update` functions to enforce the validators.  `image_path` is excluded because we do not require that field to be submitted at all.
- Updated the `MaxValueValidator` to 17500.00 per ticket request.
- Added unit tests to verify enforcement of configured validators.

## Requests / Responses

**Request to create/update product with price lower than minimum value validator**

PUT `/products/103`  -> Attempts to update a product with a price that's too low (same response for create)

```json
{
    "created_date": "2021-02-12",
	"name": "TEST",
	"price":-1,
	"quantity": 60,
	"description": "It flies high",
	"category_id": 6,
	"location": "Pittsburgh"
}
```

**Response**

HTTP/1.1 400 BAD REQUEST

```json
{
    "message": {
        "price": [
            [
                "Ensure this value is greater than or equal to 0.0."
            ]
        ]
    }
}
```

**Request to create/update a product with price higher than maximum value validator**

POST `/products`  -> Attempts to create a product with a price that's too high (same response for update)

```json
{
    "created_date": "2021-02-12",
	"name": "TEST2",
	"price":99999999999,
	"quantity": 60,
	"description": "It flies high",
	"category_id": 6,
	"location": "Pittsburgh"
}
```

**Response**

HTTP/1.1 400 BAD REQUEST

```json
{
    "message": {
        "price": [
            [
                "Ensure this value is less than or equal to 17500.0."
            ]
        ]
    }
}
```


## Testing

Description of how to test code...

- [ ] Run test suite  -> `python manage.py test tests.ProductTests -v 1`

```
$ python manage.py test tests.ProductTests -v 1
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
.........
----------------------------------------------------------------------
Ran 9 tests in 0.638s

OK
Destroying test database for alias 'default'...
```


## Related Issues

- Fixes #10