### PR TITLE
Nw/enhancement/12 get products by location

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -265,6 +265,7 @@ class Products(ViewSet):
         direction = self.request.query_params.get('direction', None)
         number_sold = self.request.query_params.get('number_sold', None)
         min_price = self.request.query_params.get('min_price', None)
+        location = self.request.query_params.get('location', None)
 
         if order is not None:
             order_filter = order
@@ -296,6 +297,9 @@ class Products(ViewSet):
                 return False
 
             products = filter(min_price_filter, products)
+
+        if location is not None:
+            products = products.filter(location__contains=location)
 
         serializer = ProductSerializer(
             products, many=True, context={'request': request})

--- a/tests/product.py
+++ b/tests/product.py
@@ -308,6 +308,37 @@ class ProductTests(APITestCase):
         self.assertEqual(json_response["message"]["price"][0][0],
                          "Ensure this value is greater than or equal to " + str(min_price) + ".")
 
+    def test_products_location_query_param(self):
+        """
+        Ensure we can filter products by their location
+        """
+
+        # Create initial product
+        self.test_create_product()
+
+        # Attempt to get our product based on the location
+        url = "/products?location=Pittsburgh"
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.get(url, None, format='json')
+        json_response = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(json_response), 1)
+        self.assertEqual(json_response[0]["name"], "Kite")
+        self.assertEqual(json_response[0]["price"], 14.99)
+        self.assertEqual(json_response[0]["quantity"], 60)
+        self.assertEqual(json_response[0]["description"], "It flies high")
+        self.assertEqual(json_response[0]["location"], "Pittsburgh")
+
+        # Attempt to get a product by location that doesn't exist
+        url = "/products?location=Philadelphia"
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.get(url, None, format='json')
+        json_response = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(json_response), 0)
+
     # TODO: Delete product
 
     # TODO: Product can be rated. Assert average rating exists.


### PR DESCRIPTION
PR creates a `location` query param and adds respective integration tests.

## Changes

- Added support for `location` query param which uses `__contains` on the location field of a product to filter for the given location.
- Added integration tests to validate `location` query param functionality.

## Requests / Responses

**Request**

GET `/products?location=bar`  - Attempts to find a product in the given location and there are results

**Response**

HTTP/1.1 200 OK

```json
[
    {
        "id": 15,
        "name": "Astro",
        "price": 762.55,
        "number_sold": 0,
        "description": "2000 Chevrolet",
        "quantity": 2,
        "created_date": "2019-03-06",
        "location": "Albarraque",
        "image_path": null,
        "average_rating": 0
    },
    {
        "id": 26,
        "name": "Eclipse",
        "price": 1095.95,
        "number_sold": 0,
        "description": "1999 Mitsubishi",
        "quantity": 3,
        "created_date": "2019-03-22",
        "location": "Pôrto Barra do Ivinheima",
        "image_path": null,
        "average_rating": 0
    }
]
```
---
**Request**

GET `/products?location=philadelphia`  - Attempts to find a product in the given location but no product is there

**Response**

HTTP/1.1 200 OK

```json
[]
```

## Testing

Description of how to test code...

- [ ] Run test suite  -> `python manage.py test tests.ProductTests.test_products_location_query_param -v 1`

```
$ python manage.py test tests.ProductTests.test_products_location_query_param -v 1
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
.
----------------------------------------------------------------------
Ran 1 test in 0.084s

OK
Destroying test database for alias 'default'...
```


## Related Issues

- Closes #12