### PR TITLE
Nw/enhancement/13 favorite seller

### DIFF
--- a/bangazonapi/models/favorite.py
+++ b/bangazonapi/models/favorite.py
@@ -6,7 +6,12 @@ from .orderproduct import OrderProduct
 from safedelete.models import SafeDeleteModel
 from safedelete.models import SOFT_DELETE
 
+
 class Favorite(models.Model):
 
     customer = models.ForeignKey(Customer, on_delete=models.DO_NOTHING,)
-    seller = models.ForeignKey(Customer, on_delete=models.DO_NOTHING, related_name='favorited_seller')
+    seller = models.ForeignKey(
+        Customer, on_delete=models.DO_NOTHING, related_name='favorited_seller')
+
+    class Meta:
+        unique_together = ('customer', 'seller')

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -1,5 +1,6 @@
 """View module for handling requests about customer profiles"""
 import datetime
+from django.db import IntegrityError
 from django.http import HttpResponseServerError
 from django.contrib.auth.models import User
 from rest_framework import serializers, status
@@ -313,7 +314,11 @@ class Profile(ViewSet):
             new_favorite = Favorite()
             new_favorite.customer = customer
             new_favorite.seller = seller
-            new_favorite.save()
+
+            try:
+                new_favorite.save()
+            except IntegrityError:
+                return Response({'message': "You have already favorited that seller."}, status=status.HTTP_400_BAD_REQUEST)
 
             return Response({}, status=status.HTTP_204_NO_CONTENT)
 

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -233,60 +233,89 @@ class Profile(ViewSet):
 
         return Response({}, status=status.HTTP_405_METHOD_NOT_ALLOWED)
 
-    @action(methods=['get'], detail=False)
+    @action(methods=['get', 'post'], detail=False)
     def favoritesellers(self, request):
-        """
-        @api {GET} /profile/favoritesellers GET favorite sellers
-        @apiName GetFavoriteSellers
-        @apiGroup UserProfile
 
-        @apiHeader {String} Authorization Auth token
-        @apiHeaderExample {String} Authorization
-            Token 9ba45f09651c5b0c404f37a2d2572c026c146611
+        if request.method == "GET":
+            """
+            @api {GET} /profile/favoritesellers GET favorite sellers
+            @apiName GetFavoriteSellers
+            @apiGroup UserProfile
 
-        @apiSuccess (200) {id} id Favorite id
-        @apiSuccess (200) {Object} seller Favorited seller
-        @apiSuccess (200) {String} seller.url Seller URI
-        @apiSuccess (200) {String} seller.phone_number Seller phone number
-        @apiSuccess (200) {String} seller.address Seller address
-        @apiSuccess (200) {String} seller.user Seller user profile URI
-        @apiSuccessExample {json} Success
-            [
-                {
-                    "id": 1,
-                    "seller": {
-                        "url": "http://localhost:8000/customers/5",
-                        "phone_number": "555-1212",
-                        "address": "100 Endless Way",
-                        "user": "http://localhost:8000/users/6"
-                    }
-                },
-                {
-                    "id": 2,
-                    "seller": {
-                        "url": "http://localhost:8000/customers/6",
-                        "phone_number": "555-1212",
-                        "address": "100 Dauntless Way",
-                        "user": "http://localhost:8000/users/7"
-                    }
-                },
-                {
-                    "id": 3,
-                    "seller": {
-                        "url": "http://localhost:8000/customers/7",
-                        "phone_number": "555-1212",
-                        "address": "100 Indefatiguable Way",
-                        "user": "http://localhost:8000/users/8"
-                    }
-                }
-            ]
-        """
-        customer = Customer.objects.get(user=request.auth.user)
-        favorites = Favorite.objects.filter(customer=customer)
+            @apiHeader {String} Authorization Auth token
+            @apiHeaderExample {String} Authorization
+                Token 9ba45f09651c5b0c404f37a2d2572c026c146611
 
-        serializer = FavoriteSerializer(
-            favorites, many=True, context={'request': request})
-        return Response(serializer.data)
+            @apiSuccess (200) {id} id Favorite id
+            @apiSuccess (200) {Object} seller Favorited seller
+            @apiSuccess (200) {String} seller.url Seller URI
+            @apiSuccess (200) {String} seller.phone_number Seller phone number
+            @apiSuccess (200) {String} seller.address Seller address
+            @apiSuccess (200) {String} seller.user Seller user profile URI
+            @apiSuccessExample {json} Success
+                [
+                    {
+                        "id": 1,
+                        "seller": {
+                            "url": "http://localhost:8000/customers/5",
+                            "phone_number": "555-1212",
+                            "address": "100 Endless Way",
+                            "user": "http://localhost:8000/users/6"
+                        }
+                    },
+                    {
+                        "id": 2,
+                        "seller": {
+                            "url": "http://localhost:8000/customers/6",
+                            "phone_number": "555-1212",
+                            "address": "100 Dauntless Way",
+                            "user": "http://localhost:8000/users/7"
+                        }
+                    },
+                    {
+                        "id": 3,
+                        "seller": {
+                            "url": "http://localhost:8000/customers/7",
+                            "phone_number": "555-1212",
+                            "address": "100 Indefatiguable Way",
+                            "user": "http://localhost:8000/users/8"
+                        }
+                    }
+                ]
+            """
+            customer = Customer.objects.get(user=request.auth.user)
+            favorites = Favorite.objects.filter(customer=customer)
+
+            serializer = FavoriteSerializer(
+                favorites, many=True, context={'request': request})
+            return Response(serializer.data)
+
+        if request.method == "POST":
+            """
+            @api {POST} /profile/favoritesellers POST new favorite seller
+            @apiName AddToFavoriteSellers
+            @apiGroup UserProfile
+
+            @apiHeader {String} Authorization Auth token
+            @apiHeaderExample {String} Authorization
+                Token 9ba45f09651c5b0c404f37a2d2572c026c146611
+
+            @apiSuccessExample {json} Success
+                HTTP/1.1 204 No Content
+            """
+            try:
+                customer = Customer.objects.get(user=request.auth.user)
+                seller = Customer.objects.get(pk=request.data["seller"])
+
+            except Customer.DoesNotExist as ex:
+                return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+
+            new_favorite = Favorite()
+            new_favorite.customer = customer
+            new_favorite.seller = seller
+            new_favorite.save()
+
+            return Response({}, status=status.HTTP_204_NO_CONTENT)
 
 
 class LineItemSerializer(serializers.HyperlinkedModelSerializer):

--- a/tests/profile.py
+++ b/tests/profile.py
@@ -127,3 +127,26 @@ class ProfileTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(json_response), 1)
         self.assertEqual(json_response[0]["id"], 1)
+
+    def test_reject_favorite_of_seller_already_favorited(self):
+        """
+        Ensure we cannot favorite a seller that is already favorited by the user
+        """
+
+        # Add the initial favorite seller
+        self.test_add_new_favorite_seller()
+
+        # Verify if we try to add that same seller as a favorite again
+        # that we get an error back
+        url = "/profile/favoritesellers"
+        data = {
+            "seller": 1
+        }
+        self.client.credentials(
+            HTTP_AUTHORIZATION="Token " + self.new_user1_token)
+        response = self.client.post(url, data, format='json')
+        json_response = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(json_response["message"],
+                         "You have already favorited that seller.")

--- a/tests/profile.py
+++ b/tests/profile.py
@@ -77,3 +77,53 @@ class ProfileTests(APITestCase):
         self.assertEqual(json_response["id"], 2)
         self.assertEqual(json_response["user"]["first_name"], "firstName")
         self.assertEqual(json_response["phone_number"], "99999")
+
+    def test_add_new_favorite_seller(self):
+        """
+        Ensure we can add a favorite seller
+        """
+        url = "/profile/favoritesellers"
+        data = {
+            "seller": 1
+        }
+        self.client.credentials(
+            HTTP_AUTHORIZATION="Token " + self.new_user1_token)
+        response = self.client.post(url, data, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_do_not_add_new_favorite_seller_that_does_not_exist(self):
+        """
+        Ensure we cannot add a favorite seller that doesn't exist
+        """
+        url = "/profile/favoritesellers"
+        data = {
+            "seller": 100
+        }
+        self.client.credentials(
+            HTTP_AUTHORIZATION="Token " + self.new_user1_token)
+        response = self.client.post(url, data, format='json')
+        json_response = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(json_response["message"],
+                         "Customer matching query does not exist.")
+
+    def test_get_current_favorite_sellers(self):
+        """
+        Ensure we can get the favorite sellers
+        """
+
+        # Add a favorite seller
+        self.test_add_new_favorite_seller()
+
+        # Get our favorite sellers
+        url = "/profile/favoritesellers"
+        self.client.credentials(
+            HTTP_AUTHORIZATION="Token " + self.new_user1_token)
+        response = self.client.get(url, None, format='json')
+        json_response = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(json_response), 1)
+        self.assertEqual(json_response[0]["id"], 1)


### PR DESCRIPTION
This PR allows for the current authenticated user to add a favorite seller to their list of favorited sellers.  It also adds 4 new integration tests to verify that we can add a favorited seller, that we _cannot_ add a non-existent seller, that we can get all favorited sellers, and that we cannot favorite an already-favorited seller.

## Changes

- Add support for POST method on the `/profile/favoritesellers` endpoint
- Add integration tests to validate `/profile/favoritesellers` endpoint responses
- Adds UNIQUE constraint on the `favorite` table so users can only favorite sellers once

## Requests / Responses

**Request**

POST `/profile/favoritesellers` Creates a new favorited seller for the current user

```json
{
    "seller": 1
}
```

**Response**

HTTP/1.1 204 No Content

```json
{}
```

---

**Request**

POST `/profile/favoritesellers` Attempts to create a favorite for a seller that doesn't exist

```json
{
    "seller": 100
}
```

**Response**

HTTP/1.1 404 Not Found

```json
{
    "message": "Customer matching query does not exist."
}
```

---


**Request**

POST `/profile/favoritesellers` Attempts to create a favorite for a seller that is already favorited

```json
{
    "seller": 1
}
```

**Response**

HTTP/1.1 400 Bad Request

```json
{
    "message": "You have already favorited that seller."
}
```


## Testing

Description of how to test code...

- [ ] Make migrations -> `python manage.py makemigrations`
- [ ] Apply migrations -> `python manage.py migrate`
- [ ] Run test suite  -> `python manage.py test tests.ProfileTests -v 1`

```
$ python manage.py test tests.ProfileTests -v 1
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
.....
----------------------------------------------------------------------
Ran 5 tests in 0.589s

OK
Destroying test database for alias 'default'...
```


## Related Issues

- Fixes #13