### PR TITLE
Nw/enhancement/14 like products

### DIFF
--- a/bangazonapi/models/__init__.py
+++ b/bangazonapi/models/__init__.py
@@ -8,3 +8,4 @@ from .recommendation import Recommendation
 from .rating import Rating
 from .favorite import Favorite
 from .productrating import ProductRating
+from .likeproduct import LikeProduct

--- a/bangazonapi/models/likeproduct.py
+++ b/bangazonapi/models/likeproduct.py
@@ -1,0 +1,20 @@
+from django.core.validators import MaxValueValidator, MinValueValidator
+from django.db import models
+from .customer import Customer
+from .product import Product
+from .productcategory import ProductCategory
+from .orderproduct import OrderProduct
+from safedelete.models import SafeDeleteModel
+from safedelete.models import SOFT_DELETE
+
+
+class LikeProduct(models.Model):
+
+    customer = models.ForeignKey(Customer, on_delete=models.DO_NOTHING,)
+    product = models.ForeignKey(Product, on_delete=models.DO_NOTHING,)
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=['customer', 'product'], name="unique product likes")
+        ]


### PR DESCRIPTION
This PR adds support for liking (and unliking) products and tests which validate that functionality.

## Changes

- New `LikeProduct` model with constraint on only liking a product once (@BrianBNeal I used that new UniqueConstraint option you mentioned in my previous PR! 😄 )
- New endpoint for `/products/n/like` which handles POST and DELETE for creating and removing likes, respectively.
- New endpoint for `/products/liked` which handles GET for listing all liked products by the user.
- New integration tests for validating the above new endpoints

## Requests / Responses

**Request**

GET `/products/liked` -> Gets list of products liked by the current authenticated user

**Response**

HTTP/1.1 200 OK

```json
[
    {
        "id": 1,
        "product": {
            "id": 1,
            "url": "http://localhost:8000/products/1",
            "name": "Optima",
            "description": "2008 Kia"
        }
    },
    {
        "id": 2,
        "product": {
            "id": 2,
            "url": "http://localhost:8000/products/2",
            "name": "Golf",
            "description": "1994 Volkswagen"
        }
    }
]
```

---

**Request**

POST `/products/3/liked` -> Likes the product with an id of 3 when a like for that product doesn't already exist

**Response**

HTTP/1.1 204 No Content

```json
{}
```

---

**Request**

DELETE `/products/2/liked` -> "Unlikes/Dislikes" the product with an id of 3 when a like for that product exists

**Response**

HTTP/1.1 204 No Content

```json
{}
```

---

**Request**

POST `/products/3/liked` -> Does not like the product with an id of 3 when a like for that product already exists

**Response**

HTTP/1.1 400 Bad Request

```json
{
    "message": "You have already liked that product."
}
```

---

**Request**

DELETE `/products/2/liked` -> Handles the error when "Unliking/Disliking" a product with an id of 2 when a like for that product doesn't already exist

**Response**

HTTP/1.1 404 Not Found

```json
{
    "message": "LikeProduct matching query does not exist."
}
```



## Testing

Description of how to test code...

- [ ] Run migrations
- [ ] Run test suite  -> `python manage.py test tests.ProductTests -v 1`

```
$ python manage.py test tests.ProductTests -v 1
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
..............
----------------------------------------------------------------------
Ran 14 tests in 0.986s

OK
Destroying test database for alias 'default'...
```


## Related Issues

- Closes #14