### PR TITLE
Added test to validate a payment type can be deleted

### DIFF
--- a/tests/payments.py
+++ b/tests/payments.py
@@ -93,3 +93,28 @@ class PaymentTests(APITestCase):
         self.assertEqual(len(json_response), 2)
 
     # TODO: Delete payment type
+    def test_delete_payment_type(self):
+        """
+        Ensure we can delete a payment type
+        """
+
+        # Create payment types for primary user
+        self.test_create_payment_type()
+        self.test_create_payment_type()
+
+        # Delete a payment
+        url = "/paymenttypes/1"
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.delete(url, None, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        # Verify we have deleted the payment type
+        url = "/paymenttypes"
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.get(url, None, format='json')
+        json_response = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(json_response), 1)
+        self.assertEqual(json_response[0]["id"], 2)


### PR DESCRIPTION
Adds a test to verify paymenttypes can be deleted.

## Changes

- Added test `test_delete_payment_type` to verify a payment type can be deleted


## Requests / Responses

**N/A - nothing changed**

## Testing

Description of how to test code...

- [ ] Run test suite  -> `python manage.py test tests.PaymentTests.test_delete_payment_type -v 1`

```
$ python manage.py test tests.PaymentTests.test_delete_payment_type -v 1
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
.
----------------------------------------------------------------------
Ran 1 test in 0.135s

OK
Destroying test database for alias 'default'...
```


## Related Issues

- Fixes #17