### PR TITLE
Added test to validate product is 'deleted' (soft deleted) and not retrieved.

### DIFF
--- a/tests/product.py
+++ b/tests/product.py
@@ -410,5 +410,31 @@ class ProductTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     # TODO: Delete product
+    def test_delete_product(self):
+        """
+        Ensure we can delete a product
+        """
+
+        # Create a couple test products
+        self.test_create_product()
+        self.test_create_product()
+
+        # Attempt to delete the second product
+        url = "/products/2"
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.delete(url, None, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        # Verify product was "deleted" (it's soft-deleted, but still won't
+        # show in the GET request)
+        url = "/products"
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.get(url, None, format='json')
+        json_response = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(json_response), 1)
+        self.assertEqual(json_response[0]["id"], 1)
 
     # TODO: Product can be rated. Assert average rating exists.


### PR DESCRIPTION
PR adds integration test to validate products can be "deleted" (soft deleted) and not returned in requests.

## Changes

- Added `test_delete_product` to test suite.


## Requests / Responses

**N/A - No changes made**

## Testing

Description of how to test code...

- [ ] Run test suite  -> `python manage.py test tests.ProductTests.test_delete_product -v 1`

```
$ python manage.py test tests.ProductTests.test_delete_product -v 1
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
.
----------------------------------------------------------------------
Ran 1 test in 0.090s

OK
Destroying test database for alias 'default'...
```


## Related Issues

- Closes #18