### PR TITLE
Added route and report for completed orders

### DIFF
--- a/bangazonreports/templates/products/completed_orders.html
+++ b/bangazonreports/templates/products/completed_orders.html
@@ -1,0 +1,51 @@
+{% load static %}
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Bangazon Reports</title>
+    <style>
+        td {
+            text-align: center;
+            padding: 3px;
+        }
+
+        th {
+            padding: 5px;
+        }
+
+        table, th, td {
+            border: 1px solid black;
+            border-collapse: collapse;
+        }
+
+        tr:nth-child(even),th {
+            background-color: #dddddd;
+        }
+    </style>
+  </head>
+  <body>
+    <h1>Completed Orders</h1>
+
+    <table>
+        <thead>
+            <tr>
+                <th>Order ID</th>
+                <th>Customer Name</th>
+                <th>Payment Type</th>
+                <th>Total Paid</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for order in order_list %}
+                <tr>
+                    <td>{{ order.order_id }}</td>
+                    <td>{{ order.customer_name }}</td>
+                    <td>{{ order.payment_type }}</td>
+                    <td>{{ order.total_paid }}</td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+  </body>
+</html>

--- a/bangazonreports/urls.py
+++ b/bangazonreports/urls.py
@@ -1,7 +1,8 @@
 from django.urls import path
-from .views import list_expensive_products, list_inexpensive_products
+from .views import list_expensive_products, list_inexpensive_products, list_completed_orders
 
 urlpatterns = [
     path('reports/expensiveproducts', list_expensive_products),
     path('reports/inexpensiveproducts', list_inexpensive_products),
+    path('reports/completedorders', list_completed_orders),
 ]

--- a/bangazonreports/views/__init__.py
+++ b/bangazonreports/views/__init__.py
@@ -1,3 +1,4 @@
 from .connection import Connection
 from .products.expensiveproducts import list_expensive_products
 from .products.inexpensiveproducts import list_inexpensive_products
+from .products.completedorders import list_completed_orders

--- a/bangazonreports/views/products/completedorders.py
+++ b/bangazonreports/views/products/completedorders.py
@@ -1,0 +1,65 @@
+"""Module for generating completed orders report"""
+import sqlite3
+from django.shortcuts import render
+from bangazonreports.views import Connection
+
+
+def list_completed_orders(request):
+    """Function to build an HTML report for completed orders"""
+    if request.method == "GET":
+        with sqlite3.connect(Connection.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            db_cursor = conn.cursor()
+
+            # Query for all orders that are completed
+            db_cursor.execute("""
+                SELECT
+	                b_op.order_id,
+	                user.first_name || ' ' || user.last_name as customer_name,
+	                b_pay.merchant_name as payment_type,
+	                sum(b_prod.price) as total_paid
+                FROM 
+                    bangazonapi_order b_ord
+                JOIN 
+                    bangazonapi_customer b_cust
+                ON
+                    b_ord.customer_id = b_cust.id
+                JOIN
+                    auth_user user
+                ON
+                    b_cust.user_id = user.id
+                JOIN
+                    bangazonapi_orderproduct b_op
+                ON
+                    b_ord.id = b_op.order_id
+                JOIN
+                    bangazonapi_product b_prod
+                ON
+                    b_op.product_id = b_prod.id
+                JOIN
+                    bangazonapi_payment b_pay
+                ON
+                    b_ord.payment_type_id = b_pay.id
+                GROUP BY
+                    order_id
+            """)
+
+            dataset = db_cursor.fetchall()
+
+            completed_orders = []
+
+            for row in dataset:
+                order = {}
+                order["order_id"] = row["order_id"]
+                order["customer_name"] = row["customer_name"]
+                order["payment_type"] = row["payment_type"]
+                order["total_paid"] = row["total_paid"]
+
+                completed_orders.append(order)
+
+        template = 'products/completed_orders.html'
+        context = {
+            'order_list': completed_orders
+        }
+
+        return render(request, template, context)


### PR DESCRIPTION
Creates endpoint to generate a 'Completed orders' report.

## Changes

- Add `/reports/completedorders` endpoint to retrieve HTML report
- Create HTML report template for completed orders

## Requests / Responses

**Request**

GET `/reports/completedorders` Creates a new completed orders report


**Response**

HTTP/1.1 200 OK

![image](https://user-images.githubusercontent.com/10491407/107983706-f49d0300-6f8b-11eb-8a07-e647651a5e66.png)


## Testing

Description of how to test code...

- [ ] Visit `/reports/completedorders`


## Related Issues

- Closes #22