### PR TITLE
Added '/reports/incompleteorders' route and report

### DIFF
--- a/bangazonreports/templates/products/incomplete_orders.html
+++ b/bangazonreports/templates/products/incomplete_orders.html
@@ -1,0 +1,49 @@
+{% load static %}
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Bangazon Reports</title>
+    <style>
+        td {
+            text-align: center;
+            padding: 3px;
+        }
+
+        th {
+            padding: 5px;
+        }
+
+        table, th, td {
+            border: 1px solid black;
+            border-collapse: collapse;
+        }
+
+        tr:nth-child(even),th {
+            background-color: #dddddd;
+        }
+    </style>
+  </head>
+  <body>
+    <h1>Incomplete Orders</h1>
+
+    <table>
+        <thead>
+            <tr>
+                <th>Order ID</th>
+                <th>Customer Name</th>
+                <th>Total Cost</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for order in order_list %}
+                <tr>
+                    <td>{{ order.order_id }}</td>
+                    <td>{{ order.customer_name }}</td>
+                    <td>{{ order.total_cost }}</td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+  </body>
+</html>

--- a/bangazonreports/urls.py
+++ b/bangazonreports/urls.py
@@ -1,8 +1,10 @@
 from django.urls import path
-from .views import list_expensive_products, list_inexpensive_products, list_completed_orders
+from .views import list_expensive_products, list_inexpensive_products, list_completed_orders, list_incomplete_orders
+
 
 urlpatterns = [
     path('reports/expensiveproducts', list_expensive_products),
     path('reports/inexpensiveproducts', list_inexpensive_products),
     path('reports/completedorders', list_completed_orders),
+    path('reports/incompleteorders', list_incomplete_orders)
 ]

--- a/bangazonreports/views/__init__.py
+++ b/bangazonreports/views/__init__.py
@@ -2,3 +2,4 @@ from .connection import Connection
 from .products.expensiveproducts import list_expensive_products
 from .products.inexpensiveproducts import list_inexpensive_products
 from .products.completedorders import list_completed_orders
+from .products.incompleteorders import list_incomplete_orders

--- a/bangazonreports/views/products/incompleteorders.py
+++ b/bangazonreports/views/products/incompleteorders.py
@@ -1,0 +1,62 @@
+"""Module for generating completed orders report"""
+import sqlite3
+from django.shortcuts import render
+from bangazonreports.views import Connection
+
+
+def list_incomplete_orders(request):
+    """Function to build an HTML report for completed orders"""
+    if request.method == "GET":
+        with sqlite3.connect(Connection.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            db_cursor = conn.cursor()
+
+            # Query for all orders that are completed
+            db_cursor.execute("""
+                SELECT
+	                b_op.order_id,
+	                user.first_name || ' ' || user.last_name as customer_name,
+	                sum(b_prod.price) as total_cost
+                FROM 
+                    bangazonapi_order b_ord
+                JOIN 
+                    bangazonapi_customer b_cust
+                ON
+                    b_ord.customer_id = b_cust.id
+                JOIN
+                    auth_user user
+                ON
+                    b_cust.user_id = user.id
+                JOIN
+                    bangazonapi_orderproduct b_op
+                ON
+                    b_ord.id = b_op.order_id
+                JOIN
+                    bangazonapi_product b_prod
+                ON
+                    b_op.product_id = b_prod.id
+                WHERE
+                    b_ord.payment_type_id
+                        IS NULL
+                GROUP BY
+                    order_id
+            """)
+
+            dataset = db_cursor.fetchall()
+
+            incomplete_orders = []
+
+            for row in dataset:
+                order = {}
+                order["order_id"] = row["order_id"]
+                order["customer_name"] = row["customer_name"]
+                order["total_cost"] = row["total_cost"]
+
+                incomplete_orders.append(order)
+
+        template = 'products/incomplete_orders.html'
+        context = {
+            'order_list': incomplete_orders
+        }
+
+        return render(request, template, context)


### PR DESCRIPTION
Creates endpoint for incomplete orders report.

## Changes

- Adds `/reports/incompleteorders` endpoint
- Adds incomplete orders HTML template for report

## Requests / Responses

**Request**

GET `/reports/incompleteorders` Creates a new incomplete orders HTML report.

**Response**

HTTP/1.1 200 OK

![image](https://user-images.githubusercontent.com/10491407/107996501-27ec8b80-6fa6-11eb-8890-0cd011afd3db.png)


## Testing

Description of how to test code...

- [ ] Visit `/reports/incompleteorders` endpoint


## Related Issues

- Closes #23